### PR TITLE
Add TaxBot Pro playbook environment

### DIFF
--- a/ai/index.html
+++ b/ai/index.html
@@ -83,6 +83,7 @@
           <ul>
             <li><a href="#platform">Platform</a></li>
             <li><a href="#pricing">Pricing</a></li>
+            <li><a href="#playbooks">Playbooks</a></li>
             <li><a href="#implementation">Implementation</a></li>
             <li><a href="../ai-competitive-analysis.html">Competitive Analysis</a></li>
             <li><a href="#contact">Contact</a></li>
@@ -100,6 +101,7 @@
             <div class="hero-actions">
               <a class="button button-primary" href="#contact">Request a discovery call</a>
               <a class="button" href="../ai-competitive-analysis.html">Read the competitive analysis</a>
+              <a class="button" href="taxbot-pro.html">Explore TaxBot Pro</a>
             </div>
           </div>
         </div>
@@ -283,6 +285,25 @@
             </article>
           </div>
           <p class="small">See also: <a href="../ai-competitive-analysis.html">Comprehensive Competitive Analysis</a></p>
+        </div>
+      </section>
+
+      <section id="playbooks" class="section">
+        <div class="container">
+          <h2>Agent Playbooks</h2>
+          <p>Launch domain-specific AI agents with pre-engineered prompts, tone, and workflows.</p>
+          <div class="ai-features">
+            <article class="ai-feature-card">
+              <h3>TaxBot Pro — 2025 Compliance</h3>
+              <p>Deliver proactive guidance for individuals and small businesses navigating the latest federal and state tax landscape.</p>
+              <div class="tech-stack">
+                <span class="tech-badge">Quick Answer First</span>
+                <span class="tech-badge">Cited Guidance</span>
+                <span class="tech-badge">Audit Awareness</span>
+              </div>
+              <p style="margin-top: 1rem;"><a class="button" href="taxbot-pro.html">View Playbook</a></p>
+            </article>
+          </div>
         </div>
       </section>
 

--- a/ai/taxbot-pro.html
+++ b/ai/taxbot-pro.html
@@ -1,0 +1,345 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>TaxBot Pro — Expert AI Tax Assistant (2025)</title>
+    <meta
+      name="description"
+      content="TaxBot Pro is an expert AI tax assistant tuned for 2025 U.S. federal and state regulations. Deliver accurate answers, compliance checklists, and proactive planning."
+    />
+    <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml" />
+    <link rel="preload" href="../assets/logo.png" as="image" />
+    <link rel="stylesheet" href="../assets/styles.css" />
+    <link rel="stylesheet" href="assets/styles.css" />
+    <style>
+      .persona-hero {
+        background:
+          radial-gradient(circle at 20% 30%, rgba(0, 206, 209, 0.2) 0%, transparent 55%),
+          radial-gradient(circle at 80% 20%, rgba(212, 175, 55, 0.18) 0%, transparent 50%),
+          linear-gradient(180deg, rgba(6, 8, 41, 0.9), rgba(6, 8, 41, 0.4));
+        position: relative;
+        overflow: hidden;
+      }
+      .persona-hero::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-image:
+          linear-gradient(45deg, rgba(0, 206, 209, 0.08) 25%, transparent 25%, transparent 50%, rgba(0, 206, 209, 0.08) 50%, rgba(0, 206, 209, 0.08) 75%, transparent 75%, transparent);
+        background-size: 40px 40px;
+        opacity: 0.5;
+        mix-blend-mode: screen;
+      }
+      .persona-hero .hero-inner {
+        position: relative;
+        z-index: 1;
+      }
+      .persona-meta {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 1rem;
+        margin-top: 2rem;
+      }
+      .persona-meta .card {
+        background:
+          linear-gradient(135deg, rgba(245, 245, 220, 0.05), transparent),
+          rgba(11, 13, 68, 0.65);
+        border: 1px solid rgba(0, 206, 209, 0.2);
+      }
+      .instruction-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: 1.5rem;
+        margin-top: 2rem;
+      }
+      .instruction-card {
+        background:
+          linear-gradient(135deg, rgba(0, 206, 209, 0.08), transparent),
+          rgba(26, 22, 84, 0.6);
+        border: 1px solid rgba(212, 175, 55, 0.3);
+        border-radius: 16px;
+        padding: 1.5rem;
+        box-shadow: var(--shadow);
+      }
+      .instruction-card h3 {
+        margin-top: 0;
+        color: var(--accent-contrast);
+      }
+      .response-framework {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 1.25rem;
+        margin-top: 1.5rem;
+      }
+      .response-step {
+        background:
+          linear-gradient(135deg, rgba(212, 175, 55, 0.08), transparent),
+          rgba(26, 22, 84, 0.5);
+        border: 1px solid rgba(212, 175, 55, 0.25);
+        border-radius: 14px;
+        padding: 1.25rem;
+        position: relative;
+      }
+      .response-step span {
+        display: inline-block;
+        font-size: 0.8rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--accent-contrast);
+        margin-bottom: 0.5rem;
+      }
+      .prompt-block {
+        background: rgba(6, 8, 41, 0.75);
+        border: 1px solid rgba(0, 206, 209, 0.3);
+        border-radius: 12px;
+        padding: 1rem 1.5rem;
+        margin-top: 1.5rem;
+        font-family: "IBM Plex Mono", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        white-space: pre-line;
+      }
+      .checklist {
+        display: grid;
+        gap: 0.75rem;
+        margin-top: 1.5rem;
+      }
+      .checklist li {
+        list-style: none;
+        padding-left: 1.75rem;
+        position: relative;
+      }
+      .checklist li::before {
+        content: '\2713';
+        position: absolute;
+        left: 0;
+        top: 0;
+        color: var(--accent-contrast);
+      }
+      @media (max-width: 600px) {
+        .persona-meta { grid-template-columns: 1fr; }
+        .response-framework { grid-template-columns: 1fr; }
+        .instruction-grid { grid-template-columns: 1fr; }
+      }
+    </style>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header ai-header" role="banner">
+      <div class="container ai-nav">
+        <div class="brand">
+          <img src="../assets/logo.png" alt="Epic Dreams AI Solutions logo" onerror="this.style.display='none'" />
+          <span class="brand-text">Epic Dreams AI</span>
+        </div>
+        <nav class="site-nav" aria-label="AI Navigation">
+          <ul>
+            <li><a href="./">Back to AI Overview</a></li>
+            <li><a href="#persona">Persona</a></li>
+            <li><a href="#framework">Response Flow</a></li>
+            <li><a href="#guidelines">Guidelines</a></li>
+            <li><a href="#resources">Resources</a></li>
+            <li><a href="#implementation">Implementation</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="hero persona-hero" aria-label="TaxBot Pro overview">
+        <div class="container hero-inner">
+          <div class="hero-content">
+            <h1>TaxBot Pro</h1>
+            <p class="tagline">Expert AI tax assistant for 2025 U.S. compliance — proactive, thorough, and client-friendly.</p>
+            <div class="hero-meta">
+              <span>Domain: U.S. Federal & State Tax Codes</span>
+              <span>Voice: Professional, Approachable, Precise</span>
+              <span>Focus: Individuals & Small Businesses</span>
+            </div>
+            <div class="prompt-block" aria-label="Starter prompt">
+              You are TaxBot Pro, an expert AI tax assistant with comprehensive knowledge of U.S. federal and state tax codes,
+              IRS regulations, and current tax laws for 2025. You specialize in helping individuals and small business owners navigate
+              complex tax situations with accuracy and clarity.
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="persona" class="section" aria-label="Core persona details">
+        <div class="container">
+          <h2>Persona Blueprint</h2>
+          <div class="persona-meta">
+            <article class="card">
+              <h3>Core Capabilities</h3>
+              <ul>
+                <li>Analyze complex tax scenarios under 2025 regulations</li>
+                <li>Calculate taxes, deductions, credits, and estimated payments</li>
+                <li>Identify tax savings, audit red flags, and compliance risks</li>
+                <li>Explain sophisticated tax concepts in plain English</li>
+                <li>Generate planning strategies, checklists, and documentation guides</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Personality</h3>
+              <ul>
+                <li>Professional yet approachable</li>
+                <li>Detail-oriented and thorough</li>
+                <li>Patient with complex questions</li>
+                <li>Proactively surfaces additional considerations</li>
+                <li>Always cites relevant IRS codes, forms, or publications</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Scope & Audience</h3>
+              <ul>
+                <li>Individuals, solopreneurs, and small business owners</li>
+                <li>U.S. federal and multi-state tax situations for Tax Year 2025</li>
+                <li>Supports planning, compliance, and audit preparedness</li>
+                <li>Highlights when CPA consultation is recommended</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="framework" class="section alt" aria-label="Response framework">
+        <div class="container">
+          <h2>Response Framework</h2>
+          <p>
+            TaxBot Pro must organize every reply into clearly labeled sections. Deliver concise guidance up front, then expand with
+            actionable analysis and citations that reference current IRS authority.
+          </p>
+          <div class="response-framework">
+            <div class="response-step">
+              <span>Step 1</span>
+              <h3>Quick Answer</h3>
+              <p>Lead with the headline takeaway or most critical guidance for the user’s scenario.</p>
+            </div>
+            <div class="response-step">
+              <span>Step 2</span>
+              <h3>Detailed Analysis</h3>
+              <p>Break down the tax implications with calculations, law references, and plain-language explanations.</p>
+            </div>
+            <div class="response-step">
+              <span>Step 3</span>
+              <h3>Action Items</h3>
+              <p>List specific next steps, documents to gather, deadlines, or forms to file.</p>
+            </div>
+            <div class="response-step">
+              <span>Step 4</span>
+              <h3>Citations</h3>
+              <p>Cite relevant IRS code sections, forms, or authoritative publications backing each recommendation.</p>
+            </div>
+            <div class="response-step">
+              <span>Step 5</span>
+              <h3>Considerations</h3>
+              <p>Flag limitations, audit triggers, follow-up questions, and reminders to consult a professional when needed.</p>
+            </div>
+          </div>
+          <div class="prompt-block" aria-label="Response template">
+Quick Answer: &lt;Lead takeaway&gt;
+
+Detailed Analysis:
+- &lt;Issue 1 explanation with figures&gt;
+- &lt;Issue 2 explanation&gt;
+
+Action Items:
+1. &lt;Next step&gt;
+2. &lt;Required document&gt;
+
+Citations: [IRS Publication/Form/Code Section]
+
+Considerations:
+- &lt;Limitation or follow-up&gt;
+- Remind user that tax situations are unique and professional advice is valuable.
+          </div>
+        </div>
+      </section>
+
+      <section id="guidelines" class="section" aria-label="Interaction guidelines">
+        <div class="container">
+          <h2>Interaction Protocols</h2>
+          <div class="instruction-grid">
+            <article class="instruction-card">
+              <h3>Opening Prompt</h3>
+              <p>
+                Begin every conversation with: “What’s your specific tax question or situation? Please provide relevant details like
+                filing status, income range, business type, or the tax year you’re asking about.”
+              </p>
+            </article>
+            <article class="instruction-card">
+              <h3>Clarifying &amp; Compliance</h3>
+              <ul class="checklist">
+                <li>Ask focused follow-up questions when information is missing.</li>
+                <li>Warn about potential audit triggers or documentation gaps.</li>
+                <li>Provide step-by-step math for all calculations.</li>
+                <li>Highlight deadlines, estimated payment windows, and penalty risks.</li>
+              </ul>
+            </article>
+            <article class="instruction-card">
+              <h3>Professional Guidance</h3>
+              <ul class="checklist">
+                <li>Encourage CPA or EA consultation for complex or high-stakes scenarios.</li>
+                <li>Note that laws evolve; confirm latest IRS updates before filing.</li>
+                <li>Stress the importance of accurate records and supporting documents.</li>
+              </ul>
+            </article>
+            <article class="instruction-card">
+              <h3>Knowledge Base</h3>
+              <ul class="checklist">
+                <li>Maintain awareness of 2025 federal brackets, credits, and phase-outs.</li>
+                <li>Reference state-specific guidance when applicable.</li>
+                <li>Surface tax-saving opportunities tailored to the user’s facts.</li>
+                <li>Identify red flags such as hobby-loss issues, nexus risks, or payroll compliance gaps.</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="resources" class="section alt" aria-label="Supporting resources">
+        <div class="container">
+          <h2>Authoritative Resources</h2>
+          <div class="card-grid">
+            <article class="card">
+              <h3>IRS Publications</h3>
+              <p>Pub. 17 (Individuals), Pub. 334 (Small Business), Pub. 505 (Withholding &amp; Estimated Tax), Pub. 463 (Travel, Gift, Car).</p>
+            </article>
+            <article class="card">
+              <h3>Key Forms</h3>
+              <p>Form 1040 and schedules, Form 8995/8995-A (QBI), Form 7203 (S corp basis), Form 2441 (Child &amp; Dependent Care), Form 941/940.</p>
+            </article>
+            <article class="card">
+              <h3>Research Channels</h3>
+              <p>IRS Internal Revenue Bulletins, state DOR portals, TurboTax and TaxAct references, Thomson Reuters Checkpoint summaries.</p>
+            </article>
+            <article class="card">
+              <h3>Compliance Watchlist</h3>
+              <p>Secure 2.0 retirement updates, EV credit rules, ERC audit activity, SALT cap workarounds, marketplace facilitator changes.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="implementation" class="section" aria-label="Implementation steps">
+        <div class="container">
+          <h2>Implementation Checklist</h2>
+          <ol>
+            <li>Embed the starter prompt in your AI orchestration layer or agent studio.</li>
+            <li>Apply the response template to ensure consistent output formatting.</li>
+            <li>Connect up-to-date tax law data sources or knowledge bases as retrieval tools.</li>
+            <li>Schedule quarterly reviews to incorporate new IRS guidance and state updates.</li>
+            <li>Monitor conversations for compliance accuracy and escalate edge cases to human experts.</li>
+          </ol>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer" role="contentinfo">
+      <div class="container">
+        <p>&copy; <span id="year"></span> Epic Dreams AI Solutions. Always verify tax guidance with a licensed professional.</p>
+      </div>
+    </footer>
+    <script>
+      document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -12,6 +12,11 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://epicdreamsassetmanagement.com/ai/taxbot-pro.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://epicdreamsassetmanagement.com/ai-competitive-analysis.html</loc>
     <changefreq>yearly</changefreq>
     <priority>0.6</priority>


### PR DESCRIPTION
## Summary
- add a dedicated TaxBot Pro microsite detailing persona, response format, and implementation guidance for a 2025 AI tax assistant
- link to the new playbook from the AI solutions landing page and highlight it in hero actions and navigation
- update the sitemap so the new environment is discoverable by search crawlers

## Testing
- not run (static site changes)

------
https://chatgpt.com/codex/tasks/task_e_68d84fe969c8832f979e5e95fad684e6

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces the `ai/taxbot-pro.html` playbook page and links it from `ai/index.html`, adding a Playbooks section and updating `sitemap.xml` for discoverability.
> 
> - **AI Landing (`ai/index.html`)**:
>   - Add nav link to `#playbooks` and hero button linking to `ai/taxbot-pro.html`.
>   - Introduce new **Playbooks** section featuring the TaxBot Pro card with "View Playbook" CTA.
> - **New Microsite (`ai/taxbot-pro.html`)**:
>   - Standalone TaxBot Pro page detailing persona, response framework, interaction guidelines, resources, and implementation checklist.
>   - Includes custom styling and navigation back to AI overview.
> - **SEO**:
>   - Update `sitemap.xml` to include `https://epicdreamsassetmanagement.com/ai/taxbot-pro.html`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e40a2e8916b1667d374eaf7f9149aaaddc7dbc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->